### PR TITLE
water-level is now used by water-temperature.

### DIFF
--- a/wp4/slowc/SlowControl.c
+++ b/wp4/slowc/SlowControl.c
@@ -352,7 +352,7 @@ float cnv_LOADCURR;
 			 (float) adc_buffer[T_AIR]/10.,
 			 (float) adc_buffer[P_AIR]/10.,
 			 (float) adc_buffer[H_AIR]/10.);
-	 printf (" T_WAT %.1f K",adc_buffer[WAT_LVL]*cnv_TM);
+	 printf (" T_WAT %.1f K",adc_buffer[WAT_TEMP]*cnv_TM);
 
 
 	 printf ("\n");

--- a/wp4/slowc/sde_sc.h
+++ b/wp4/slowc/sde_sc.h
@@ -33,7 +33,7 @@ K.H. Becker
 #define SP_CURR   34
 #define SP_VOLT   42
 #define BAT_OUT   50
-#define WAT_LVL   58
+#define WAT_TEMP  58
 
 #define ADC7      3  //chan 3
 #define ADC6      11
@@ -83,7 +83,7 @@ K.H. Becker
 #define P_AIR	  64	//Air pressure
 #define T_AIR     65    //Air temperature
 #define H_AIR     66    //SCU temperature
-#define T_WAT     67    //Water temperatur (0xffff if not present)
+//#define unused     67
 #define MAX_VARS 68
 uint8_t act_mask;
 #define UPD_PRESS 0x01


### PR DESCRIPTION
As discussed with Karl-Heinz, the field 58 is now water-temperature. The slow-control command was actually already using the '58', so no change in functionality, just clearer.